### PR TITLE
マイページ及びアーティスト詳細ページのタグ可視化の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,4 @@
 @import "modules/tag";
 @import "modules/artist";
 @import "modules/album";
+@import "modules/user";

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -1,0 +1,40 @@
+@import "variable";
+
+#current-user-mypage--wrapper {
+  width: 100%;
+}
+
+#current-user-mypage {
+  min-height: 250px;
+  padding: 50px 0;
+  background-color: #666666;
+}
+
+#current-user-mypage--bgmask {
+  height: 150px;
+  width: 100%;
+  margin: 0;
+  background-color: $whiteOpacity5;
+}
+
+#current-user-mypage__title--wrapper {
+  padding: 20px 10px;
+}
+
+#current-user-mypage__title h2 {
+  margin: 0;
+}
+
+#current-user-mypage__icon--wrapper {
+  max-height: 120px;
+  max-width: 165px;
+  padding-right: 30px;
+}
+
+#current-user-mypage__icon {
+  height: 120px;
+  width: 120px;
+  border: medium double;
+  border-color: #f8f9fa;
+  object-fit: cover;
+}

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -3,4 +3,15 @@ class ArtistsController < ApplicationController
 
   def show
   end
+
+  # アルバムに最も多くついたタグのidを抽出
+  def tagged_search
+    album_id = params[:id]
+    @most_tagged_tag_id = ArtistsTaggedSearchService.new(album_id).get_most_tagged_tag_id
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,13 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    user = current_user
+    @album_ids_hash = UsersShowService.new(user).get_album_ids
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
+end

--- a/app/services/artists_tagged_search_service.rb
+++ b/app/services/artists_tagged_search_service.rb
@@ -1,0 +1,10 @@
+class ArtistsTaggedSearchService
+  def initialize(album_id)
+    @album_id = album_id
+  end
+
+  def get_most_tagged_tag_id
+    album_grouping_tagged_tag_id = Album.includes(:taggings).where(spotify_id: @album_id).references(:taggings).group(:tag_id)
+    most_tagged_tag_id = album_grouping_tagged_tag_id.order('count_id desc').count().keys.first
+  end
+end

--- a/app/services/users_show_service.rb
+++ b/app/services/users_show_service.rb
@@ -1,0 +1,14 @@
+class UsersShowService
+def initialize(user)
+  @current_user = user
+end
+
+  def get_album_ids
+    # ログイン中ユーザがタグ付けしたアルバム(最新順)
+    album_current_user = Album.includes(:taggings).where('taggings.tagger_id = ?', @current_user.id).references(:taggings).group(:spotify_id).order('albums.id desc')
+    album_spotify_id = album_current_user.pluck(:spotify_id)
+    album_tag_id =  album_current_user.pluck(:tag_id) #ログイン中ユーザが選択したタグ
+    album_ids =[album_spotify_id, album_tag_id].transpose
+    album_ids_hash = Hash[*album_ids.flatten] #{album_spotify_id: album_tag_id}という形のハッシュを作成
+  end
+end

--- a/app/views/artists/tagged_search.json.jbuilder
+++ b/app/views/artists/tagged_search.json.jbuilder
@@ -1,0 +1,1 @@
+json.tagId @most_tagged_tag_id

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -10,11 +10,11 @@
     %ul.nav.navbar-nav.navbar-right.list-inline.w-100.nav-justified.justify-content-end
       - if user_signed_in?
         %li#user-sign-out.list-inline-item
-          = button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-light d-flex align-items-center'
+          = button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-light user-btn d-flex align-items-center'
         %li#user-mypage.list-inline-item
-          = link_to 'マイページ', user_path(current_user), class: 'btn btn-info d-flex align-items-center'
+          = link_to 'マイページ', user_path(current_user), class: 'btn btn-info user-btn d-flex align-items-center'
       - else
         %li#user-sign-in.list-inline-item
-          = link_to 'サインイン', new_user_session_path, class: 'btn btn-light d-flex align-items-center'
+          = link_to 'サインイン', new_user_session_path, class: 'btn btn-light user-btn d-flex align-items-center'
         %li#user-mypage.list-inline-item
-          = link_to '新規登録', new_user_registration_path, class: 'btn btn-primary d-flex align-items-center'
+          = link_to '新規登録', new_user_registration_path, class: 'btn btn-primary user-btn d-flex align-items-center'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,18 @@
+#current-user-mypage--wrapper
+  -# タイトル(ユーザ名)
+  #current-user-mypage
+    #current-user-mypage--bgmask.row.justify-content-between.d-flex.align-items-center
+      #current-user-mypage__title--wrapper.col-md-auto
+        #current-user-mypage__title
+          %h2
+            = current_user.name
+
+      -# アイコン画像
+      #current-user-mypage__icon--wrapper.col-md
+        %img#current-user-mypage__icon.rounded-circle.img-fluid{ src: current_user.icon }
+
+  -# ユーザがタグ付けしたアルバム一覧
+  .album-index.text-center
+    %h4.album-index__title
+      あなたの印象履歴
+    %ul.album-index__lists.list-inline

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @album_ids_hash  do |key, value|
+  json.spotifyAlbumId key
+  json.tagId value
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:'tags#index'
+  post 'artists/tagged/:id', to: 'artists#tagged_search'
   resources :artists, only: [:show]
   resources :albums, only: [:create, :show]
   resources :tags, only: [:index, :show]


### PR DESCRIPTION
# WHAT
- マイページのビュー実装
- マイページ及びアーティスト詳細ページのアルバム一覧について、ボタン色に付与されたタグを反映する機能の実装
  - マイページ:これまでに当該ユーザが付与してきたタグの履歴を反映
  - アーティスト詳細ページ:そのアルバムに対して付与されたタグの中で最も多く付与されたたものを反映

# WHY
必須機能であるため。

- マイページ
<img width="1277" alt="2018-10-01 4 06 36" src="https://user-images.githubusercontent.com/39646282/46261510-7dd44c00-c52f-11e8-9483-001cef2d0a29.png">

- アルバム詳細ページ
<img width="1279" alt="2018-10-01 4 06 00" src="https://user-images.githubusercontent.com/39646282/46261513-87f64a80-c52f-11e8-94ed-856dc8a15f44.png">
