### PR TITLE
アカウント凍結機能の実装

### DIFF
--- a/app/views/tags/index.html.haml
+++ b/app/views/tags/index.html.haml
@@ -1,3 +1,10 @@
+- if flash[:alert]
+  #freeze-alert.alert.alert-danger.alert-dismissible.fade.show
+    %strong
+      投稿が制限されています。
+    %button.close.close-button{type: 'button', data: {dismiss: 'alert', turbolinks: false}, onClick: 'window.location.reload();'}
+      %span.close-button__chara{aria: {hidden: true}}×
+
 #application-name.row.justify-content-center.pt-3
   = image_tag 'Logos made simple2000.png', alt: 'Logo', id: 'application-name__img'
 

--- a/db/migrate/20181027064055_add_column_ban_to_users.rb
+++ b/db/migrate/20181027064055_add_column_ban_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnBanToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :ban, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180921134127) do
+ActiveRecord::Schema.define(version: 20181027064055) do
 
   create_table "albums", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "spotify_id", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20180921134127) do
     t.string   "icon_content_type"
     t.integer  "icon_file_size"
     t.datetime "icon_updated_at"
+    t.string   "ban"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
# WHAT
普通の使用では起こりえない頻度でのタグ付けが行われた際、
該当ユーザの投稿を阻止する機能の実装。

# WHY
リスク回避のため。

実装は以下のような流れで行いました。
https://docs.google.com/spreadsheets/d/1r-ULh_Dzm61f1R5cVngTMeG37ctcsnt4SjpkfAUp7_0/edit#gid=0